### PR TITLE
improve build

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ let timer = process.hrtime();
 
 exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`,
   (err, stdout) => {
+    console.log(stdout);
     if (err) {
-      console.error(stdout);
       console.error(err);
       process.exit(1);
     }

--- a/index.js
+++ b/index.js
@@ -41,11 +41,16 @@ const converter = createConverter({
 });
 
 const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');
+const dotnetOutPath = path.join(dotnetProject, 'bin')
 
 let timer = process.hrtime();
 
+exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`)
+
+const dotnetDll = path.join(dotnetOutPath, "csharp-models-to-json.dll")
+
 exec(
-  `dotnet run --project "${dotnetProject}" "${path.resolve(configPath)}"`,
+  `dotnet "${dotnetDll}" "${path.resolve(configPath)}"`,
   (err, stdout) => {
     if (err) {
       console.error(err);

--- a/index.js
+++ b/index.js
@@ -45,7 +45,15 @@ const dotnetOutPath = path.join(dotnetProject, 'bin')
 
 let timer = process.hrtime();
 
-exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`)
+exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`,
+  (err, stdout) => {
+    if (err) {
+      console.error(stdout);
+      console.error(err);
+      process.exit(1);
+    }
+  }
+);
 
 const dotnetDll = path.join(dotnetOutPath, "csharp-models-to-json.dll")
 
@@ -65,7 +73,7 @@ exec(
       console.error(
         'The output from `csharp-models-to-json` contains invalid JSON.'
       );
-			process.exit(1);
+      process.exit(1);
     }
 
     const types = converter(json);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ const path = require('path');
 const { exec } = require('child_process');
 
 const createConverter = require('./converter');
-const { builtinModules } = require('module');
-const { runInContext } = require('vm');
 
 const configArg = process.argv.find(x => x.startsWith('--config='));
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const path = require('path');
 const { exec } = require('child_process');
 
 const createConverter = require('./converter');
+const { builtinModules } = require('module');
+const { runInContext } = require('vm');
 
 const configArg = process.argv.find(x => x.startsWith('--config='));
 
@@ -45,46 +47,55 @@ const dotnetOutPath = path.join(dotnetProject, 'bin')
 
 let timer = process.hrtime();
 
-exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`,
-  (err, stdout) => {
-    console.log(stdout);
-    if (err) {
-      console.error(err);
-      process.exit(1);
-    }
-  }
-);
-
 const dotnetDll = path.join(dotnetOutPath, "csharp-models-to-json.dll")
 
-exec(
-  `dotnet "${dotnetDll}" "${path.resolve(configPath)}"`,
-  (err, stdout) => {
-    if (err) {
-      console.error(err);
-      process.exit(1);
-    }
+function build_and_run()
+{
+    exec(`dotnet build -c Release "${dotnetProject}" -o "${dotnetOutPath}"`,
+    (err, stdout) => {
+        console.log(stdout);
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
 
-    let json;
 
-    try {
-      json = JSON.parse(stdout);
-    } catch (error) {
-      console.error(
-        'The output from `csharp-models-to-json` contains invalid JSON.'
-      );
-      process.exit(1);
-    }
-
-    const types = converter(json);
-
-    fs.writeFile(output, types, err => {
-      if (err) {
-        return console.error(err);
-      }
-
-      timer = process.hrtime(timer);
-      console.log('Done in %d.%d seconds.', timer[0], timer[1]);
+        run();
     });
-  }
-);
+}
+
+function run()
+{
+    exec(
+        `dotnet "${dotnetDll}" "${path.resolve(configPath)}"`,
+        (err, stdout) => {
+            if (err) {
+            console.error(err);
+            process.exit(1);
+            }
+
+            let json;
+
+            try {
+            json = JSON.parse(stdout);
+            } catch (error) {
+            console.error(
+                'The output from `csharp-models-to-json` contains invalid JSON.'
+            );
+            process.exit(1);
+            }
+
+            const types = converter(json);
+
+            fs.writeFile(output, types, err => {
+            if (err) {
+                return console.error(err);
+            }
+
+            timer = process.hrtime(timer);
+            console.log('Done in %d.%d seconds.', timer[0], timer[1]);
+            });
+        });
+}
+
+build_and_run();

--- a/lib/csharp-models-to-json/csharp-models-to-json.csproj
+++ b/lib/csharp-models-to-json/csharp-models-to-json.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Build warning from `dotnet run` interferes with legitimate program output.
Warnings arise from dotnet sdk outdated version.

This change splits running the tool to a build stage and a separate execute stage.

Пока не мержите это, пожалуйста. Нужно проверить ссылки на мастер из dodo-is и других репо.