### PR TITLE
Отмечать поля контракта deprecated, если в C# модели они отмечены [Obsolete]

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -124,7 +124,7 @@ const createConverter = config => {
       );
     }
 
-    const deprecationMark = property.IsObsolete ? `\t/** @deprecated */` : ``
+    const deprecationMark = property.IsObsolete ? `\t/** @deprecated */\n` : ``
 
     return `${deprecationMark}\t${identifier}: ${type}`;
   };

--- a/converter.js
+++ b/converter.js
@@ -124,7 +124,9 @@ const createConverter = config => {
       );
     }
 
-    return `\t${identifier}: ${type}`;
+    const deprecationMark = property.IsObsolete ? `\t/** @deprecated */` : ``
+
+    return `${deprecationMark}\t${identifier}: ${type}`;
   };
 
   const convertIdentifier = identifier =>

--- a/lib/csharp-models-to-json/ModelInspection/FieldInfo.cs
+++ b/lib/csharp-models-to-json/ModelInspection/FieldInfo.cs
@@ -5,5 +5,7 @@ namespace CSharpModelsToJson.ModelInspection
         public string Identifier { get; set; }
 
         public string Type { get; set; }
+
+        public bool IsObsolete { get; set; }
     }
 }

--- a/lib/csharp-models-to-json/ModelInspection/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelInspection/ModelCollector.cs
@@ -54,6 +54,7 @@ namespace CSharpModelsToJson.ModelInspection
             {
                 Identifier = field.Declaration.Variables.First().GetText().ToString(),
                 Type = field.Declaration.Type.ToString(),
+                IsObsolete = field.AttributeLists.Any(IsObsolete),
             };
         }
 
@@ -63,10 +64,11 @@ namespace CSharpModelsToJson.ModelInspection
             {
                 Identifier = property.Identifier.ToString(),
                 Type = property.Type.ToString(),
-                IsObsolete = property.AttributeLists.Any(IsObsolete)
+                IsObsolete = property.AttributeLists.Any(IsObsolete),
             };
         }
 
-        private static bool IsObsolete(AttributeListSyntax a) => a.Attributes.SingleOrDefault()?.Name.ToString() == "Obsolete";
+        private static bool IsObsolete(AttributeListSyntax a) =>
+            a.Attributes.SingleOrDefault()?.Name.ToString() == "Obsolete";
     }
 }

--- a/lib/csharp-models-to-json/ModelInspection/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelInspection/ModelCollector.cs
@@ -63,7 +63,10 @@ namespace CSharpModelsToJson.ModelInspection
             {
                 Identifier = property.Identifier.ToString(),
                 Type = property.Type.ToString(),
+                IsObsolete = property.AttributeLists.Any(IsObsolete)
             };
         }
+
+        private static bool IsObsolete(AttributeListSyntax a) => a.Attributes.SingleOrDefault()?.Name.ToString() == "Obsolete";
     }
 }

--- a/lib/csharp-models-to-json/ModelInspection/PropertyInfo.cs
+++ b/lib/csharp-models-to-json/ModelInspection/PropertyInfo.cs
@@ -5,5 +5,7 @@ namespace CSharpModelsToJson.ModelInspection
         public string Identifier { get; set; }
 
         public string Type { get; set; }
+
+        public bool IsObsolete { get; set; }
     }
 }

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -134,23 +134,30 @@ namespace CSharpModelsToJson.Tests
             var tree = CSharpSyntaxTree.ParseText(@"
                 public class A
                 {
-                    public int NonObsoleteField { get; set; }
+                    public int NonObsoleteProperty { get; set; }
 
                     [Obsolete]
-                    public int ObsoleteField { get; set; }
+                    public int ObsoleteProperty { get; set; }
+
+                    [Obsolete]
+                    public int ObsoleteField;
                 }"
             );
-            
+
             var root = (CompilationUnitSyntax)tree.GetRoot();
             var modelCollector = new ModelCollector();
             modelCollector.Visit(root);
             var modelProperties = modelCollector.Models.Single().Properties.ToArray();
-            
-            Assert.That(modelProperties[0].Identifier, Is.EqualTo("NonObsoleteField"));
+            var modelFields = modelCollector.Models.Single().Fields.ToArray();
+
+            Assert.That(modelProperties[0].Identifier, Is.EqualTo("NonObsoleteProperty"));
             Assert.That(modelProperties[0].IsObsolete, Is.False);
-            
-            Assert.That(modelProperties[1].Identifier, Is.EqualTo("ObsoleteField"));
+
+            Assert.That(modelProperties[1].Identifier, Is.EqualTo("ObsoleteProperty"));
             Assert.That(modelProperties[1].IsObsolete, Is.True);
+
+            Assert.That(modelFields[0].Identifier, Is.EqualTo("ObsoleteField"));
+            Assert.That(modelFields[0].IsObsolete, Is.True);
         }
     }
 }

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -23,7 +23,7 @@ namespace CSharpModelsToJson.Tests
                 }"
             );
 
-            var root = (CompilationUnitSyntax) tree.GetRoot();
+            var root = (CompilationUnitSyntax)tree.GetRoot();
 
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
@@ -65,7 +65,7 @@ namespace CSharpModelsToJson.Tests
                 }"
             );
 
-            var root = (CompilationUnitSyntax) tree.GetRoot();
+            var root = (CompilationUnitSyntax)tree.GetRoot();
 
             var modelCollector = new ModelCollector();
             modelCollector.Visit(root);
@@ -80,7 +80,7 @@ namespace CSharpModelsToJson.Tests
         public void TypedInheritance_ReturnsInheritance()
         {
             const string baseClasses = "IController<Controller>";
-            
+
             var tree = CSharpSyntaxTree.ParseText(@"
                 public class A : IController<Controller>
                 {
@@ -90,7 +90,7 @@ namespace CSharpModelsToJson.Tests
                 }"
             );
 
-            var root = (CompilationUnitSyntax) tree.GetRoot();
+            var root = (CompilationUnitSyntax)tree.GetRoot();
 
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
@@ -118,7 +118,7 @@ namespace CSharpModelsToJson.Tests
                 }"
             );
 
-            var root = (CompilationUnitSyntax) tree.GetRoot();
+            var root = (CompilationUnitSyntax)tree.GetRoot();
 
             var modelCollector = new ModelCollector();
             modelCollector.VisitClassDeclaration(root.DescendantNodes().OfType<ClassDeclarationSyntax>().First());
@@ -126,6 +126,31 @@ namespace CSharpModelsToJson.Tests
             Assert.IsNotNull(modelCollector.Models);
             Assert.IsNotNull(modelCollector.Models.First().Properties);
             Assert.AreEqual(modelCollector.Models.First().Properties.Count(), 1);
+        }
+
+        [Test]
+        public void ObsoleteFields_ShouldBeMarkedObsolete()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public class A
+                {
+                    public int NonObsoleteField { get; set; }
+
+                    [Obsolete]
+                    public int ObsoleteField { get; set; }
+                }"
+            );
+            
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var modelCollector = new ModelCollector();
+            modelCollector.Visit(root);
+            var modelProperties = modelCollector.Models.Single().Properties.ToArray();
+            
+            Assert.That(modelProperties[0].Identifier, Is.EqualTo("NonObsoleteField"));
+            Assert.That(modelProperties[0].IsObsolete, Is.False);
+            
+            Assert.That(modelProperties[1].Identifier, Is.EqualTo("ObsoleteField"));
+            Assert.That(modelProperties[1].IsObsolete, Is.True);
         }
     }
 }

--- a/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
+++ b/lib/csharp-models-to-json_test/csharp-models-to-json_test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />


### PR DESCRIPTION
Пример:
Код на C#
```cs
public class Model 
{
    public string NewField { get; set; }
    
    [Obsolete]
    public string OldField { get; set; }
}
```
Конвертится в:
```ts
export interface Model {
  NewField: string;
  /** @deprecated */
  OldField: string;
}
```